### PR TITLE
Sensors landing page updates

### DIFF
--- a/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.html
+++ b/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.html
@@ -1,108 +1,121 @@
-    <div class="search-section" [hidden]="!isSearchVisible">
-      <div class="search-input-wrapper">
-        <input type="text" [(ngModel)]="searchQuery" placeholder="Search sensors" (input)="onSearchInputChange()" />
-        <mat-icon matPrefix class="search-icon">search</mat-icon>
-      </div>
-    </div>
+<div class="sensors-landing-page">
+  <div class="search-section" [hidden]="!isSearchVisible">
+    <input type="text" class="searchbox" [(ngModel)]="searchQuery" placeholder="Search sensors"
+      (input)="onSearchInputChange()" />
+  </div>
 
-    <div class="filter-section" [hidden]="!isFilterVisible">
-      <div class="filter-buttons">
+  <div class="filter-section" [hidden]="!isFilterVisible">
+    <div class="filter-buttons">
 
-        <!-- Connection Status -->
-        <div class="filter-button-group">
-          <ng-container *ngFor="let option of filterOptions.connectionStatusOptions; let isFirst = first">
-              <ng-container *ngIf="isFirst">
-                <h2 class="filter-heading">Status</h2>
-              </ng-container>
-              <button
-                class="filter-button"
-                (click)="toggleFilterOption(option)"
-                [class.active]="isSelectedFilterOption(option)"
-              >
-                {{ option }}
-              </button>
-          </ng-container>
-        </div>
-
-        <!-- Field Location -->
-        <div class="filter-button-group">
-          <ng-container *ngFor="let option of filterOptions.fieldLocationOptions; let isFirst = first">
-            <ng-container *ngIf="isFirst">
-              <h2 class="filter-heading">Field Location</h2>
-            </ng-container>
-            <button
-              class="filter-button"
-              (click)="toggleFilterOption(option)"
-              [class.active]="isSelectedFilterOption(option)"
-            >
-              {{ option }}
-            </button>
-          </ng-container>
-        </div>
-        <button
-          class="clear-filters-button"
-          (click)="clearFilter()"
-          [class.active]="selectedFilterOptions.length === 0"
-        >
-          Clear Filter
-        </button>
-      </div>
-    </div>
-
-    <div class="filteredby-section" [hidden]="!isFilteredByVisible">
-      <span class="filter-label">Filtered by</span>
+      <!-- Connection Status -->
       <div class="filter-button-group">
-        <ng-container *ngFor="let option of selectedFilterOptions">
-          <button
-            class="filter-button"
-            (click)="toggleFilterOption(option)"
-            [class.active]="isSelectedFilterOption(option)"
-          >
-            {{ option }}
+        <ng-container *ngFor="let option of filterOptions.connectionStatusOptions; let isFirst = first">
+          <ng-container *ngIf="isFirst">
+            <h2 class="filter-heading">Status</h2>
+          </ng-container>
+          <button class="filter-button" (click)="toggleFilterOption(option)"
+            [class.active]="isSelectedFilterOption(option)">
+            <span [class.no-field-selected]="option === null">
+              {{ option === null ? noFieldSelectedText : option }}
+            </span>
           </button>
         </ng-container>
       </div>
-      <button
-      class="clear-filters-button"
-      (click)="clearFilter()"
-      [class.active]="selectedFilterOptions.length === 0"
-    >
-      Clear Filter
-    </button>
-    </div>
 
-    <!-- Display the filtered and sorted items -->
-    <div class="sensor-results" [hidden]="isFilterVisible">
-      <mat-list>
-        <ng-container *ngIf="displayedItems.length > 0; else noItemsFound">
-          <mat-list-item *ngFor="let item of displayedItems">
-            <a mat-list-item class="sensorLink" [ngClass]="{'offline': item.connectionStatus === 'Not Connected'}">
-              <h4 mat-line class="lastUpdatedTime">{{ item.lastUpdated }}</h4>
-              <p mat-line class="menu-list-body">
-                <span class="sensorInfo">
-                  {{ item.sensorName }} <span class="sensorSpacer">&#183;</span> {{ item.fieldLocation }}
-                </span>
-                <span class="sensorMoisture">Moisture Level: {{ item.moistureLevel }}</span>
-              </p>
-            </a>
-          </mat-list-item>
+      <!-- Field Location -->
+      <div class="filter-button-group">
+        <ng-container *ngFor="let option of filterOptions.fieldLocationOptions; let isFirst = first">
+          <ng-container *ngIf="isFirst">
+            <h2 class="filter-heading">Field Location</h2>
+          </ng-container>
+          <button class="filter-button" (click)="toggleFilterOption(option)"
+            [class.active]="isSelectedFilterOption(option)">
+            <span [class.no-field-selected]="option === null">
+              {{ option === null ? noFieldSelectedText : option }}
+            </span>
+          </button>
         </ng-container>
-      </mat-list>
+      </div>
+      <button class="clear-filters-button" (click)="clearFilter()" [class.active]="selectedFilterOptions.length === 0">
+        Clear Filters
+      </button>
+    </div>
+  </div>
 
-      <ng-template #noItemsFound>
-        <div class="no-sensors">
-          <mat-icon class="no-sensor-icon">sensors_off</mat-icon>
+  <div class="filteredby-section" [hidden]="!isFilteredByVisible">
+    <span class="filter-label">Filtered by</span>
+    <div class="filter-button-group">
+      <ng-container *ngFor="let option of selectedFilterOptions">
+        <button class="filter-button" [class.active]="isSelectedFilterOption(option)" disabled>
+          <span [class.no-field-selected]="option === null">
+            {{ option === null ? noFieldSelectedText : option }}
+          </span>
+        </button>
+      </ng-container>
+    </div>
+    <button class="clear-filters-button" (click)="clearFilter()" [class.active]="selectedFilterOptions.length === 0">
+      Clear Filters
+    </button>
+  </div>
 
-          <div class="no-sensors-title">
-            No sensors detected
-          </div>
+  <div class="sortedby-section" [hidden]="!isSortedByVisible">
+    <span class="sort-label">Sorted by </span>
+    <span class="sort-option">
+      {{ selectedSortLabel }}
+    </span>
+  </div>
 
-          <div class="no-sensors-text">
-            <p>Check that wifi and bluetooth are enabled on your device and the sensors are turned on.</p>
 
-            <p>You may need to set up your gateways first. See the user manual for instructions.</p>
-          </div>
+  <!-- Display the filtered and sorted items -->
+  <div class="sensor-results" [hidden]="isFilterVisible">
+    <mat-list>
+      <ng-container *ngIf="displayedItems.length > 0; else noResults">
+        <mat-list-item *ngFor="let item of displayedItems">
+          <a mat-list-item class="sensorLink" [ngClass]="{'offline': item.connectionStatus === 'Not Connected'}">
+            <h4 mat-line class="lastUpdatedTime">{{ item.lastUpdated }}</h4>
+            <p mat-line class="menu-list-body">
+              <span class="sensor-info">
+                {{ item.sensorName }} <span class="sensorSpacer">&#183;</span>
+                <span [class.no-field-selected]="item.fieldLocation === null">
+                  {{ item.fieldLocation === null ? noFieldSelectedText : item.fieldLocation }}
+                </span>
+                <span class="sensor-moisture">
+                  <span *ngIf="item.moistureLevel; else moistureLevelNotDetected">
+                    Moisture Level: {{ item.moistureLevel }}
+                  </span>
+                  <ng-template #moistureLevelNotDetected>
+                    Moisture levels not detected. Check connection.
+                  </ng-template>
+                </span>
+              </span>
+            </p>
+          </a>
+        </mat-list-item>
+      </ng-container>
+    </mat-list>
+
+    <ng-template #noResults>
+      <div class="no-results" *ngIf="originalDisplayedItemsLength !== 0 && displayedItems.length === 0 && selectedFilterOptions.length === 0">
+        <div class="no-sensors-text">
+          <p>No sensors found with these parameters.</p>
+          <p>{{clearSearchDisplayText}}</p>
+        </div>
+      </div>
+
+      <div class="no-sensors" *ngIf="originalDisplayedItemsLength === 0">
+        <mat-icon class="no-sensor-icon">sensors_off</mat-icon>
+
+        <div class="no-sensors-title">
+          No sensors detected
         </div>
 
-      </ng-template>
-    </div>
+        <div class="no-sensors-text">
+          <p>Check that wifi and bluetooth are enabled on your device and the sensors are turned on.</p>
+          <p>You may need to set up your gateways first. See the user manual for instructions.</p>
+        </div>
+      </div>
+  </ng-template>
+
+
+  </div>
+</div>

--- a/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.scss
+++ b/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.scss
@@ -1,3 +1,7 @@
+.sensors-landing-page span {
+  font-family: 'IBM Plex Sans' !important;
+}
+
 .lastUpdatedTime {
   color: #8D8D8D;
   font-size: 10px !important;
@@ -23,7 +27,7 @@
   border-left: solid 4px #FF2F2F;
 }
 
-.sensorInfo {
+.sensor-info {
   color: #262626;
   font-size: 16px;
   font-weight: 400;
@@ -32,19 +36,29 @@
 
 .sensorSpacer {
   font-size: 30px;
-  vertical-align: middle;
+  vertical-align: text-bottom;
+  margin-right: 4px;
 }
 
-.sensorMoisture,
-.sensorInfo {
+.sensor-moisture,
+.sensor-info {
   display: block;
+}
+
+.sensor-moisture {
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0.25px;
+}
+
+.no-field-selected {
+  font-style: italic;
 }
 
 .sensorBody {
   margin: 0;
   padding: 0;
 }
-
 
 .filter-section,
 .filteredby-section,
@@ -55,9 +69,15 @@
   }
 }
 
-.search-section,
+.sortedby-section {
+  padding: 11px 16px;
+}
+
+.filteredby-section,
+.sortedby-section,
 .search-section {
   background-color: #F4F4F4;
+  border-bottom: 1px solid #E0E0E0;
 }
 
 .search-section {
@@ -65,10 +85,11 @@
     padding: 8px 26px 8px 8px;
     font-size: 16px;
     width: calc(100% - 32px);
+    &.searchbox:focus-visible {
+      outline: 1px solid #0f62fe;
+    }
   }
-  .search-input-wrapper {
-    position: relative;
-  }
+
   .mat-icon {
     position: absolute;
     top: 6px;
@@ -121,6 +142,16 @@
   margin-bottom: 10px;
 }
 
+.sort-label {
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.sort-option {
+  font-size: 14px;
+  font-weight: 400;
+}
+
 .filter-heading {
   color: #262626;
   font-size: 15px !important;
@@ -137,12 +168,11 @@
   width: 100%;
 }
 
-.no-sensors {
+.no-sensors,
+.no-results {
   padding: 36px 16px;
   text-align: center;
-  p {
-    margin-bottom: 25px;
-  }
+
   .no-sensor-icon {
     width: 48px;
     height: 48px;
@@ -164,6 +194,12 @@
     text-align: center;
     font-size: 16px;
     font-weight: 400;
+  }
+}
+
+.no-sensors {
+  p {
+    margin-bottom: 25px;
   }
 }
 

--- a/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.ts
+++ b/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.ts
@@ -319,8 +319,8 @@ getSelectedFilterOptions() {
       });
       if (this.selectedFilterOptions.length > 0) {
         this.isFilteredByVisible = true;
-        this.isSortedByVisible = true;
       }
+      this.isSortedByVisible = true;
     }
 
   }

--- a/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.ts
+++ b/liquid-prep-app/src/app/components/dashboard/sensors/sensors.component.ts
@@ -14,7 +14,9 @@ import { DatePipe } from '@angular/common';
 })
 export class SensorsComponent implements OnInit {
 
-  selectedSortOption: string = '';
+  selectedSortOption: string = 'lastUpdated';
+  selectedSortLabel: string = 'last updated time';
+  noFieldSelectedText: string = 'No field selected';
   selectedFilterOption: string = '';
   selectedFilterOptions: string[] = [];
   filterOptions: {
@@ -26,8 +28,11 @@ export class SensorsComponent implements OnInit {
   isFilterVisible: boolean = false;
   isFilteredByVisible: boolean = false;
   isSearchVisible: boolean = false;
+  isSortedByVisible: boolean = true;
   displayedItems: any[] = [];
   searchQuery: string = '';
+  clearSearchDisplayText: string = 'Clear search to see all sensors.';
+  originalDisplayedItemsLength: number;
 
   headerConfig: HeaderConfig = {
     headerTitle: 'Sensors',
@@ -59,7 +64,7 @@ export class SensorsComponent implements OnInit {
     {
       lastUpdated: '1632215520',
       sensorName: 'A3',
-      fieldLocation: 'Field 2',
+      fieldLocation: null,
       moistureLevel: 42,
       connectionStatus: 'Connected',
     },
@@ -81,7 +86,7 @@ export class SensorsComponent implements OnInit {
       lastUpdated: '1691813700',
       sensorName: 'A1',
       fieldLocation: 'Field 5',
-      moistureLevel: 44,
+      moistureLevel: null,
       connectionStatus: 'Not Connected',
     },
   ];
@@ -119,10 +124,21 @@ export class SensorsComponent implements OnInit {
     this.filterOptions = this.getSelectedFilterOptions();
     this.filterOptions.connectionStatusOptions.sort();
     this.filterOptions.fieldLocationOptions.sort();
+
+
+
     this.lastSelectedSortOption = this.selectedSortOption;
 
     // Initialize displayedItems with the original sensor data
     this.displayedItems = [...this.items];
+    this.originalDisplayedItemsLength = this.displayedItems.length;
+
+    if (this.displayedItems.length === 0) {
+      this.isFilterVisible = false;
+      this.isSearchVisible = false;
+      this.isFilteredByVisible = false;
+      this.isSortedByVisible = false;
+    }
 
     // Convert Date format
     this.items.forEach((item) => {
@@ -156,12 +172,16 @@ export class SensorsComponent implements OnInit {
   openSortModal() {
     const dialogRef = this.dialog.open(SortModalComponent, {
       width: '80%',
-      data: { selectedSortOption: this.lastSelectedSortOption },
+      data: {
+        selectedSortOption: this.selectedSortOption,
+        selectedSortLabel: this.selectedSortLabel
+      },
     });
 
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result) {
-        this.selectedSortOption = result;
+    dialogRef.afterClosed().subscribe((selection) => {
+      if (selection) {
+        this.selectedSortOption = selection.selectedSortOption;
+        this.selectedSortLabel = selection.selectedSortLabel.toLowerCase();
         this.lastSelectedSortOption = this.selectedSortOption;
         this.sortItems();
       }
@@ -223,6 +243,7 @@ toggleConnectionStatusSort(statusA: string, statusB: string): number {
     // Update the displayedItems with the filtered and sorted items
     this.displayedItems = filteredItems;
     this.toggleFilter();
+    this.isSortedByVisible = true;
   }
 
   clearFilter() {
@@ -236,21 +257,32 @@ toggleConnectionStatusSort(statusA: string, statusB: string): number {
     this.toggleFilter();
   }
 
-  // Get filter sellections
-  getSelectedFilterOptions() {
-    const selectedConnectionStatus = new Set<string>();
-    const selectedFieldLocation = new Set<string>();
+// Get filter selections
+getSelectedFilterOptions() {
+  const selectedConnectionStatus = new Set<string>();
+  const fieldLocationOptions = new Set<string>(); // Use a Set to deduplicate options
 
-    this.items.forEach((item) => {
-      selectedConnectionStatus.add(item.connectionStatus);
-      selectedFieldLocation.add(item.fieldLocation);
-    });
+  this.items.forEach((item) => {
+    selectedConnectionStatus.add(item.connectionStatus);
+    if (item.fieldLocation !== null) {
+      fieldLocationOptions.add(item.fieldLocation);
+    }
+  });
 
-    return {
-      connectionStatusOptions: Array.from(selectedConnectionStatus),
-      fieldLocationOptions: Array.from(selectedFieldLocation),
-    };
+  // Convert the Sets back to arrays
+  const connectionStatusOptions = Array.from(selectedConnectionStatus);
+  const fieldLocationArray = Array.from(fieldLocationOptions);
+
+  // Add "No field selected" at the top if it exists
+  if (this.items.some((item) => item.fieldLocation === null)) {
+    fieldLocationArray.unshift(null);
   }
+
+  return {
+    connectionStatusOptions,
+    fieldLocationOptions: fieldLocationArray,
+  };
+}
 
   isSelectedFilterOption(option: string): boolean {
     return this.selectedFilterOptions.includes(option);
@@ -262,6 +294,7 @@ toggleConnectionStatusSort(statusA: string, statusB: string): number {
     if (this.isFilterVisible) {
       this.isSearchVisible = false;
       this.isFilteredByVisible = false;
+      this.isSortedByVisible = false;
 
       this.headerService.updateHeader({
         headerTitle: null,
@@ -286,6 +319,7 @@ toggleConnectionStatusSort(statusA: string, statusB: string): number {
       });
       if (this.selectedFilterOptions.length > 0) {
         this.isFilteredByVisible = true;
+        this.isSortedByVisible = true;
       }
     }
 
@@ -298,6 +332,7 @@ toggleConnectionStatusSort(statusA: string, statusB: string): number {
     if (this.isSearchVisible) {
       this.isFilterVisible = false;
       this.isFilteredByVisible = false;
+      this.isSortedByVisible = false;
     }
 
   }
@@ -308,13 +343,11 @@ toggleConnectionStatusSort(statusA: string, statusB: string): number {
 
   applySearchFilter() {
     this.displayedItems = this.items.filter((item) => {
-
       return (
         item.sensorName.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
-        item.fieldLocation.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
-        item.moistureLevel.toString().toLowerCase().includes(this.searchQuery.toLowerCase())
+        (item.fieldLocation && item.fieldLocation.toLowerCase().includes(this.searchQuery.toLowerCase())) || // Check if fieldLocation is not null
+        (item.moistureLevel && item.moistureLevel.toString().toLowerCase().includes(this.searchQuery.toLowerCase())) // Check if moistureLevel is not null
       );
     });
   }
-
 }

--- a/liquid-prep-app/src/app/components/sort-modal/sort-modal.component.ts
+++ b/liquid-prep-app/src/app/components/sort-modal/sort-modal.component.ts
@@ -10,12 +10,14 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 export class SortModalComponent implements OnInit {
   title: string;
   selectedSortOption: string = 'lastUpdated';
+  selectedSortLabel: string = 'Last Updated';
 
   constructor(
     public dialogRef: MatDialogRef<SortModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     this.selectedSortOption = data.selectedSortOption || 'lastUpdated';
+    this.selectedSortLabel = this.getLabelForSortOption(this.selectedSortOption);
   }
 
   ngOnInit(): void {}
@@ -25,6 +27,25 @@ export class SortModalComponent implements OnInit {
   }
 
   saveSelection() {
-    this.dialogRef.close(this.selectedSortOption);
+    const selection = {
+      selectedSortOption: this.selectedSortOption,
+      selectedSortLabel: this.getLabelForSortOption(this.selectedSortOption)
+    };
+    this.dialogRef.close(selection);
+  }
+
+  getLabelForSortOption(option: string): string {
+    switch (option) {
+      case 'lastUpdated':
+        return 'Last Updated Time';
+      case 'sensorName':
+        return 'Sensor Name (A-Z)';
+      case 'fieldLocation':
+        return 'Field Location (A-Z)';
+      case 'connectionStatus':
+        return 'Connection Status';
+      default:
+        return '';
+    }
   }
 }


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
Design Change Requests:

1. Sensors with no connection should read “Moisture levels not detected. Check connection.”
2. On the Filters page/section, the link now says “Clear Filters”.
3. Added a section on the landing page to indicate the sort order. This section should be persistent so that the user can always see the order that the list is sorted in.
4. When there are no sensors matching a search, the page should display this message (not the default empty state, since that only applies when there are no sensors connected).

**Is this a patch, a minor version change, or a major version change**
minor

**Is this related to an open issue?**
https://trello.com/c/oHeqJm0b

